### PR TITLE
Volume UI Fix

### DIFF
--- a/videogular.js
+++ b/videogular.js
@@ -1407,10 +1407,11 @@ angular.module("com.2fdevs.videogular")
             return (navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) || navigator.userAgent.match(/iPad/i));
         };
 
-        /**
+        /*
          * Test the browser's support for HTML5 localStorage.
          * @returns {boolean}
          */
+
         this.supportsLocalStorage = function () {
             var testKey = 'videogular-test-key';
             var storage = $window.sessionStorage;


### PR DESCRIPTION
In Chrome with Mac, and on Windows it happens on Chrome, IE and Firefox When you Click in the middle of the bar it shuts the volume control instead of letting you adjust the volume. 
Steps to recreate :
-Click the unmute button
-Click somewhere in the middle of the volume bar

Volume bar would also stick to the cursor on hover. 
Steps to recreate :
-open volume bar
-click volume
- mouse up and drag

Changes made to the mouse events to adjust the way the volume bar reacts. 
